### PR TITLE
Sync localStorage state between instances

### DIFF
--- a/app/(overwolf)/app/page.tsx
+++ b/app/(overwolf)/app/page.tsx
@@ -5,7 +5,7 @@ const App = dynamic(() => import("./app"), {
 });
 
 export const metadata = {
-  title: "Controller - Diablo 4 Map",
+  title: "Diablo 4 Map",
 };
 
 export default function Page() {

--- a/app/(overwolf)/controller/init.tsx
+++ b/app/(overwolf)/controller/init.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { GAME_CLASS_ID, HOTKEYS, WINDOWS } from "../lib/config";
 import { getRunningGameInfo } from "../lib/games";
 import { waitForOverwolf } from "../lib/overwolf";
@@ -12,15 +12,15 @@ import {
   toggleWindow,
 } from "../lib/windows";
 
-let initialized = false;
 export default function Init() {
+  const initialized = useRef(false);
   useEffect(() => {
-    if (initialized) {
+    if (initialized.current) {
       return;
     }
     waitForOverwolf()
       .then(() => {
-        initialized = true;
+        initialized.current = true;
         initController();
       })
       .catch((error) => console.warn(error));

--- a/app/lib/storage.ts
+++ b/app/lib/storage.ts
@@ -1,5 +1,28 @@
-import { create } from "zustand";
+import { Mutate, StoreApi, create } from "zustand";
 import { persist } from "zustand/middleware";
+
+type StoreWithPersist<State = any> = Mutate<
+  StoreApi<State>,
+  [["zustand/persist", State]]
+>;
+
+export const withStorageDOMEvents = (store: StoreWithPersist) => {
+  const storageEventCallback = (e: StorageEvent) => {
+    try {
+      if (e.key && e.key === store.persist.getOptions().name && e.newValue) {
+        store.persist.rehydrate();
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  window.addEventListener("storage", storageEventCallback);
+
+  return () => {
+    window.removeEventListener("storage", storageEventCallback);
+  };
+};
 
 export const useDiscoveredNodesStore = create(
   persist<{
@@ -23,6 +46,8 @@ export const useDiscoveredNodesStore = create(
     }
   )
 );
+
+withStorageDOMEvents(useDiscoveredNodesStore);
 
 export const useSettingsStore = create(
   persist<{
@@ -54,3 +79,5 @@ export const useSettingsStore = create(
     }
   )
 );
+
+withStorageDOMEvents(useSettingsStore);


### PR DESCRIPTION
- Fix the issue, that the app hotkey opens a new instance of the app.
- Discovered nodes are synced between browser tabs